### PR TITLE
Admin Screen UI layout

### DIFF
--- a/lib/common/widgets/custom_textfield.dart
+++ b/lib/common/widgets/custom_textfield.dart
@@ -5,12 +5,12 @@ class CustomTextField extends StatelessWidget {
   final TextEditingController controller;
   final String hintText;
   final int maxLines;
-  const CustomTextField(
-      {Key? key,
-      required this.controller,
-      required this.hintText,
-      this.maxLines = 1})
-      : super(key: key);
+  const CustomTextField({
+    Key? key,
+    required this.controller,
+    required this.hintText,
+    this.maxLines = 1,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/admin/screens/add_product_screen.dart
+++ b/lib/features/admin/screens/add_product_screen.dart
@@ -1,0 +1,175 @@
+import 'package:amazon_clone_tech387/common/widgets/custom_button.dart';
+import 'package:amazon_clone_tech387/common/widgets/custom_textfield.dart';
+import 'package:dotted_border/dotted_border.dart';
+import 'package:flutter/material.dart';
+
+import '../../../constants/global_variables.dart';
+
+class AddProductScreen extends StatefulWidget {
+  static const String routeName =
+      '/add-product'; // register this route in router.dart file
+  const AddProductScreen({super.key});
+
+  @override
+  State<AddProductScreen> createState() => _AddProductScreenState();
+}
+
+class _AddProductScreenState extends State<AddProductScreen> {
+  /**
+   * Whenever the user modifies a text field with an associated [TextEditingController], 
+   * the text field updates [value] and the controller notifies its listeners. 
+   * Listeners can then read the [text] and [selection] properties to learn what
+   * the user has typed or how the selection has been updated.
+   */
+  final TextEditingController productNameController = TextEditingController();
+  final TextEditingController descriptionController = TextEditingController();
+  final TextEditingController priceController = TextEditingController();
+  final TextEditingController quantityController = TextEditingController();
+
+  /**
+   * The framework calls this method when this [State] object will never build again.
+   * After the framework calls [dispose], the [State] object is considered unmounted 
+   * and the [mounted] property is false. It is an error to call [setState] at this point. 
+   * This stage of the lifecycle is terminal: there is no way to remount a [State] object that has been disposed.
+   */
+
+  String category = 'Mobiles';
+
+  @override
+  void dispose() {
+    super.dispose();
+    productNameController.dispose();
+    descriptionController.dispose();
+    priceController.dispose();
+    quantityController.dispose();
+  }
+
+  List<String> productCategories = [
+    'Mobiles',
+    'Essentials',
+    'Appliances',
+    'Books',
+    'Fashion'
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: PreferredSize(
+        preferredSize: const Size.fromHeight(50),
+        child: AppBar(
+          flexibleSpace: Container(
+            decoration: const BoxDecoration(
+              gradient: GlobalVariables.appBarGradient,
+            ),
+          ),
+          title: const Text(
+            'Add Product',
+            style: TextStyle(color: Colors.black),
+          ),
+        ),
+      ),
+      body: SingleChildScrollView(
+        child: Form(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: Column(
+              children: [
+                const SizedBox(
+                  height: 20,
+                ),
+                DottedBorder(
+                  borderType: BorderType.RRect,
+                  radius: const Radius.circular(10),
+                  dashPattern: const [10, 4],
+                  strokeCap: StrokeCap.round,
+                  child: Container(
+                    width: double.infinity,
+                    height: 150,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Icon(
+                          Icons.folder_open_outlined,
+                          size: 40,
+                        ),
+                        const SizedBox(
+                          height: 15,
+                        ),
+                        Text(
+                          'Select Product Images',
+                          style: TextStyle(
+                              fontSize: 15, color: Colors.grey.shade400),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(
+                  height: 30,
+                ),
+                CustomTextField(
+                  controller: productNameController,
+                  hintText: 'Product Name',
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                CustomTextField(
+                  controller: descriptionController,
+                  hintText: 'Description',
+                  maxLines: 7,
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                CustomTextField(
+                  controller: priceController,
+                  hintText: 'Price',
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                CustomTextField(
+                  controller: quantityController,
+                  hintText: 'Quantity',
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                SizedBox(
+                  width: double.infinity,
+                  child: DropdownButton(
+                    value: category,
+                    icon: const Icon(Icons.keyboard_arrow_down),
+                    items: productCategories.map((String item) {
+                      return DropdownMenuItem(
+                        value: item,
+                        child: Text(item),
+                      );
+                    }).toList(),
+                    onChanged: (String? newVal) {
+                      setState(() {
+                        category = newVal!;
+                      });
+                    },
+                  ),
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                CustomButton(
+                  text: 'Sell',
+                  onTap: () {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/admin/screens/admin_screen.dart
+++ b/lib/features/admin/screens/admin_screen.dart
@@ -1,0 +1,139 @@
+import 'package:amazon_clone_tech387/features/admin/screens/posts_screen.dart';
+import 'package:flutter/material.dart';
+
+import '../../../constants/global_variables.dart';
+
+class AdminScreen extends StatefulWidget {
+  const AdminScreen({super.key});
+
+  @override
+  State<AdminScreen> createState() => _AdminScreenState();
+}
+
+class _AdminScreenState extends State<AdminScreen> {
+  int _page = 0;
+  double bottomBarWidth = 42;
+  double bottomBarBorderWidth = 5;
+
+  List<Widget> pages = [
+    const PostsScreen(),
+    const Center(
+      child: Text('Analytics Page'),
+    ),
+    const Center(
+      child: Text('Cart Page'),
+    ),
+  ];
+
+  void updatePage(int page) {
+    setState(() {
+      _page = page;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: PreferredSize(
+        preferredSize: const Size.fromHeight(50),
+        child: AppBar(
+          flexibleSpace: Container(
+            decoration: const BoxDecoration(
+              gradient: GlobalVariables.appBarGradient,
+            ),
+          ),
+          title: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Container(
+                alignment: Alignment.topLeft,
+                child: Image.asset(
+                  'assets/images/amazon_in_logo.png',
+                  width: 120,
+                  height: 45,
+                  color: Colors.black,
+                ),
+              ),
+              const Text(
+                'Admin',
+                style:
+                    TextStyle(fontWeight: FontWeight.bold, color: Colors.black),
+              ),
+            ],
+          ),
+        ),
+      ),
+      body: pages[_page],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _page,
+        selectedItemColor: GlobalVariables.selectedNavBarColor,
+        unselectedItemColor: GlobalVariables.unselectedNavBarColor,
+        backgroundColor: GlobalVariables.backgroundColor,
+        iconSize: 28,
+        onTap: updatePage,
+        items: [
+          // POSTS
+          BottomNavigationBarItem(
+            icon: Container(
+              width: bottomBarWidth,
+              decoration: BoxDecoration(
+                border: Border(
+                  top: BorderSide(
+                    color: _page == 0
+                        ? GlobalVariables.selectedNavBarColor
+                        : GlobalVariables.backgroundColor,
+                    width: bottomBarBorderWidth,
+                  ),
+                ),
+              ),
+              child: const Icon(
+                Icons.home_outlined,
+              ),
+            ),
+            label: '',
+          ),
+          // ANALYTICS
+          BottomNavigationBarItem(
+            icon: Container(
+              width: bottomBarWidth,
+              decoration: BoxDecoration(
+                border: Border(
+                  top: BorderSide(
+                    color: _page == 1
+                        ? GlobalVariables.selectedNavBarColor
+                        : GlobalVariables.backgroundColor,
+                    width: bottomBarBorderWidth,
+                  ),
+                ),
+              ),
+              child: const Icon(
+                Icons.analytics_outlined,
+              ),
+            ),
+            label: '',
+          ),
+          // ORDERS
+          BottomNavigationBarItem(
+            icon: Container(
+              width: bottomBarWidth,
+              decoration: BoxDecoration(
+                border: Border(
+                  top: BorderSide(
+                    color: _page == 2
+                        ? GlobalVariables.selectedNavBarColor
+                        : GlobalVariables.backgroundColor,
+                    width: bottomBarBorderWidth,
+                  ),
+                ),
+              ),
+              child: const Icon(
+                Icons.all_inbox_outlined,
+              ),
+            ),
+            label: '',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/admin/screens/posts_screen.dart
+++ b/lib/features/admin/screens/posts_screen.dart
@@ -1,0 +1,30 @@
+import 'package:amazon_clone_tech387/features/admin/screens/add_product_screen.dart';
+import 'package:flutter/material.dart';
+
+class PostsScreen extends StatefulWidget {
+  const PostsScreen({super.key});
+
+  @override
+  State<PostsScreen> createState() => _PostsScreenState();
+}
+
+class _PostsScreenState extends State<PostsScreen> {
+  void navigateToAddProduct() {
+    Navigator.pushNamed(context, AddProductScreen.routeName);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: const Center(
+        child: Text('Products'),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: navigateToAddProduct,
+        tooltip: 'Add a Product', // hold a click on button to see this message
+        child: const Icon(Icons.add),
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:amazon_clone_tech387/common/widgets/bottom_bar.dart';
 import 'package:amazon_clone_tech387/constants/global_variables.dart';
+import 'package:amazon_clone_tech387/features/admin/screens/admin_screen.dart';
 import 'package:amazon_clone_tech387/features/auth/screens/auth_screen.dart';
 import 'package:amazon_clone_tech387/features/auth/services/auth_service.dart';
 import 'package:amazon_clone_tech387/providers/user_provider.dart';
@@ -35,7 +36,9 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Amazon Clone',
+      debugShowCheckedModeBanner:
+          false, // This banner is intended to deter people from complaining that your app is slow when it's in debug mode.
+      title: 'Green Flutter Bank',
       theme: ThemeData(
         scaffoldBackgroundColor: GlobalVariables.backgroundColor,
         // ignore: prefer_const_constructors
@@ -51,7 +54,9 @@ class _MyAppState extends State<MyApp> {
       ),
       onGenerateRoute: (settings) => generateRoute(settings),
       home: Provider.of<UserProvider>(context).user.token.isNotEmpty
-          ? const BottomBar()
+          ? Provider.of<UserProvider>(context).user.type == 'user'
+              ? const BottomBar()
+              : const AdminScreen()
           : const AuthScreen(),
     );
   }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,4 +1,6 @@
 import 'package:amazon_clone_tech387/common/widgets/bottom_bar.dart';
+import 'package:amazon_clone_tech387/features/admin/screens/add_product_screen.dart';
+import 'package:amazon_clone_tech387/features/admin/screens/posts_screen.dart';
 import 'package:amazon_clone_tech387/features/auth/screens/auth_screen.dart';
 import 'package:amazon_clone_tech387/features/home/screens/home_screen.dart';
 import 'package:flutter/material.dart';
@@ -20,6 +22,11 @@ Route<dynamic> generateRoute(RouteSettings routeSettings) {
       return MaterialPageRoute(
         settings: routeSettings,
         builder: (_) => const BottomBar(),
+      );
+    case AddProductScreen.routeName:
+      return MaterialPageRoute(
+        settings: routeSettings,
+        builder: (_) => const AddProductScreen(),
       );
     default:
       return MaterialPageRoute(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
+  dotted_border:
+    dependency: "direct main"
+    description:
+      name: dotted_border
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0+3"
   fake_async:
     dependency: transitive
     description:
@@ -163,6 +170,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
+  path_drawing:
+    dependency: transitive
+    description:
+      name: path_drawing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   path_provider_linux:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   shared_preferences: ^2.0.15
   badges: ^2.0.3
   carousel_slider: ^4.1.1
+  dotted_border: ^2.0.0+3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- in _lib/features_ directory created **admin** folder with subfolder **screens**
- in screens folder created _Stateful Widget_ `admin_screen.dart`
- implemented conditional rendering in `main.dart` where we get admin screen if user is not equal = 'user' but equal to admin = 'admin'
- created `appBar` similar to the one from the `account_screen.dart`
- created admin bottom navbar with routing for 3 pages (_posts, analytics, orders_)
- created` posts_screen.dart` _Stateful Widget_
- implemented `floatingActionButton` feature, which help us to go to a new page where we can add products
- created `add_product_screen.dart`
- register a new route name for products in `router.dart` ( '/add-product' )
- in `AddProductScreen` widget created `Form()`
- created 4 **Text Editing** controllers for fields
- built dropdown menu with list of categories that are available
- rendered categories from _List_ using `.map()` method